### PR TITLE
Add exclusion file for Python's verificarlo build

### DIFF
--- a/code/verificarlo/fuzzy-python/Dockerfile.rebuildpython
+++ b/code/verificarlo/fuzzy-python/Dockerfile.rebuildpython
@@ -29,6 +29,8 @@ RUN mkdir -p /opt/build/ && \
 
 RUN cd /opt/build/Python-3.6.5 && make
 
+# Restore default behavior for verificarlo's CC
+ENV CC "verificarlo"
 ENV VERIFICARLO_MCAMODE "MCA"
 ENV VERIFICARLO_BACKEND "QUAD"
 

--- a/code/verificarlo/fuzzy-python/Dockerfile.rebuildpython
+++ b/code/verificarlo/fuzzy-python/Dockerfile.rebuildpython
@@ -7,10 +7,11 @@ RUN apt-get update -qqq &&\
                             xz-utils tk-dev wget &&\
     rm -rf /var/lib/apt/lists/
 
-# Copying the patched version which does an fPIC compilation instead of static
-COPY verificarlo /usr/local/bin/verificarlo
+# Copy verificarlo's exclusion file for Python 3
+COPY python-vfc-exclude.txt /tmp/python-vfc-exclude.txt
 
-ENV CC "verificarlo"
+# When compiling C, use exclusion file
+ENV CC "verificarlo --exclude-file /tmp/python-vfc-exclude.txt"
 ENV FC "verificarlo"
 ENV LD "verificarlo"
 ENV LDSHARED "verificarlo -shared"
@@ -24,11 +25,9 @@ RUN mkdir -p /opt/build/ && \
     cd /opt/build/ && \
     wget https://www.python.org/ftp/python/3.6.5/Python-3.6.5.tgz && \
     tar xvf Python-3.6.5.tgz && \
-    cd Python-3.6.5 && \
-    ./configure --enable-optimizations --with-ensurepip=install
+    cd Python-3.6.5 && ./configure --enable-optimizations --with-ensurepip=install
 
-RUN cd /opt/build/Python-3.6.5 && \
-    make
+RUN cd /opt/build/Python-3.6.5 && make
 
 ENV VERIFICARLO_MCAMODE "MCA"
 ENV VERIFICARLO_BACKEND "QUAD"

--- a/code/verificarlo/fuzzy-python/python-vfc-exclude.txt
+++ b/code/verificarlo/fuzzy-python/python-vfc-exclude.txt
@@ -1,0 +1,9 @@
+# exclusion list for compiling python 3.6.5 with verificarlo
+# parse floating point numbers, sensitive to FP errors
+Python/dtoa *
+Python/formatter_unicode *
+# require unique hashing every time
+Python/pyhash *
+# we should not mess with python internal scheduler clock
+Python/pytime *
+Python/sysmodule *


### PR DESCRIPTION
Adds an exclusion file to verificarlo's build of python. The resulting Python build seems to implement MCA arithmetic for all configurations and does not break or hangs on simple examples.

The explicit copy of local verificarlo was removed, since the latest docker image verificarlo/verificarlo:latest includes verificarlo/verificarlo#86 and verificarlo/verificarlo#88.

@gkiar: you may want to discard this merge and integrate the changes directly into the main Dockerfile (instead of Dockerfile.rebuildpython).

Thanks!
